### PR TITLE
fix: typo and broken link

### DIFF
--- a/vm/src/chips/chips/alu/sll/constraints.rs
+++ b/vm/src/chips/chips/alu/sll/constraints.rs
@@ -47,7 +47,7 @@ where
             // Check shift_by_n_bits[i] is 1 if i = num_bits_to_shift.
             let mut num_bits_to_shift = zero.clone();
 
-            //  num_bits_to_shift = event.c as usize % BYTE_SIZE, so the maximum value of num_bits_to_shift is 7, just neeed 3 bits to calculate this.
+            //  num_bits_to_shift = event.c as usize % BYTE_SIZE, so the maximum value of num_bits_to_shift is 7, just need 3 bits to calculate this.
             for i in 0..3 {
                 num_bits_to_shift += c_lsb[i] * F::from_canonical_u32(1 << i);
             }

--- a/vm/src/emulator/riscv/emulator/instruction.rs
+++ b/vm/src/emulator/riscv/emulator/instruction.rs
@@ -376,7 +376,7 @@ impl RiscvEmulator {
                 self.alu_rw(instruction, rd, a, b, c);
             }
 
-            // See https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#instruction-aliases
+            // See https://github.com/riscv-non-isa/riscv-asm-manual/blob/main/src/asm-manual.adoc#instruction-aliases
             Opcode::UNIMP => {
                 return Err(EmulationError::Unimplemented());
             }


### PR DESCRIPTION
Hi! While working on the code, I noticed a couple of small but important issues:

1. **Typo in `constraints.rs`:**
   - Before: `just neeed 3 bits to calculate this.`
   - After: `just need 3 bits to calculate this.`
   - Looks like someone (maybe me) was in a hurry and missed a letter. Fixed it.

2. **Broken link in `instruction.rs`:**
   - Before: `https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md#instruction-aliases`
   - After: `https://github.com/riscv-non-isa/riscv-asm-manual/blob/main/src/asm-manual.adoc#instruction-aliases`
   - The link was pointing to a non-existent page. Updated it to the correct one.

The changes are minimal, but they improve readability and accuracy.