### PR TITLE
Correcting typos in code comments and docs

### DIFF
--- a/sdk/sdk/src/vk_client.rs
+++ b/sdk/sdk/src/vk_client.rs
@@ -90,7 +90,7 @@ macro_rules! create_sdk_prove_vk_client {
             }
 
             /// prove and serialize embed proof, which provided to next step gnark verifier.
-            /// the constraints.json and groth16_witness.json will be genererated in output dir.
+            /// the constraints.json and groth16_witness.json will be generated in output dir.
             pub fn prove(
                 &self,
                 output: PathBuf,

--- a/vm/src/chips/chips/riscv_memory/initialize_finalize/columns.rs
+++ b/vm/src/chips/chips/riscv_memory/initialize_finalize/columns.rs
@@ -41,6 +41,6 @@ pub struct MemoryInitializeFinalizeCols<T> {
     /// Auxilary column, equal to `(1 - is_prev_addr_zero.result) * is_first_row`.
     pub is_first_comp: T,
 
-    /// A flag to inidicate the last non-padded address. An auxiliary column needed for degree 3.
+    /// A flag to indicate the last non-padded address. An auxiliary column needed for degree 3.
     pub is_last_addr: T,
 }

--- a/vm/src/chips/chips/riscv_memory/read_write/constraints.rs
+++ b/vm/src/chips/chips/riscv_memory/read_write/constraints.rs
@@ -318,7 +318,7 @@ impl<F: Field> MemoryReadWriteChip<F> {
             + mem_val[3] * local.offset_is_three;
         let byte_value = Word::extend_expr::<CB>(mem_byte.clone());
 
-        // When the instruciton is LB or LBU, just use the lower byte.
+        // When the instruction is LB or LBU, just use the lower byte.
         builder
             .when(local.instruction.is_lb + local.instruction.is_lbu)
             .assert_word_eq(byte_value, local.unsigned_mem_val.map(|x| x.into()));

--- a/vm/src/emulator/riscv/emulator/mod.rs
+++ b/vm/src/emulator/riscv/emulator/mod.rs
@@ -36,7 +36,7 @@ pub use util::align;
 
 /// An emulator for the Pico RISC-V zkVM.
 ///
-/// The exeuctor is responsible for executing a user program and tracing important events which
+/// The executor is responsible for executing a user program and tracing important events which
 /// occur during emulation (i.e., memory reads, alu operations, etc).
 pub struct RiscvEmulator {
     /// The program.

--- a/vm/src/emulator/riscv/state.rs
+++ b/vm/src/emulator/riscv/state.rs
@@ -11,7 +11,7 @@ use crate::{
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RiscvEmulationState {
-    /// The global clock keeps track of how many instrutions have been emulated through all chunks.
+    /// The global clock keeps track of how many instructions have been emulated through all chunks.
     pub global_clk: u64,
 
     /// Current batch number


### PR DESCRIPTION
# Fix Typos in Multiple Files

Hey! While reviewing the code, I stumbled upon a few typos in comments and documentation. These are minor changes, but they help improve the overall clarity and professionalism of the codebase.