### PR TITLE
Grammar and Typo Fixes

### DIFF
--- a/vm/examples/parse_elf.rs
+++ b/vm/examples/parse_elf.rs
@@ -19,5 +19,5 @@ fn main() {
 
     println!("instructions length: {}", instructions.len());
     // group instructions by Opcode
-    //et grouped = instructions.into_iter().group_by(|i| i.opcode);
+    // let grouped = instructions.into_iter().group_by(|i| i.opcode);
 }

--- a/vm/examples/test_e2e.rs
+++ b/vm/examples/test_e2e.rs
@@ -421,7 +421,7 @@ macro_rules! run {
 
             info!(
                 "The EMBED proof is verified: {} (at {:?})",
-                compress_result.is_ok(),
+                embed_result.is_ok(),
                 start.elapsed()
             );
             assert!(embed_result.is_ok());

--- a/vm/src/compiler/riscv/instruction.rs
+++ b/vm/src/compiler/riscv/instruction.rs
@@ -72,7 +72,7 @@ impl Instruction {
         )
     }
 
-    /// Returns if the instruction is a ecall instruction.
+    /// Returns if the instruction is an ecall instruction.
     #[must_use]
     pub fn is_ecall_instruction(&self) -> bool {
         self.opcode == Opcode::ECALL

--- a/vm/src/configs/config.rs
+++ b/vm/src/configs/config.rs
@@ -85,7 +85,7 @@ pub trait ZeroCommitment<SC: StarkGenericConfig> {
 /// instantiation should satisfy them here rather than at chip instantiation.
 pub trait Poseidon2Config: Copy {
     type FullRounds: ArraySize + Add<typenum::U3, Output: ArraySize> + core::fmt::Debug;
-    // the add constraint enforces external rounds is even
+    // the add constraint enforces that external rounds is even
     type HalfFullRounds: ArraySize
         + Add<Self::HalfFullRounds, Output: Same<Self::FullRounds>>
         + core::fmt::Debug;


### PR DESCRIPTION


Old: //et grouped = instructions.into_iter().group_by(|i| i.opcode);
New: // let grouped = instructions.into_iter().group_by(|i| i.opcode);
Reason: Fix typo ("et" → "let").


Old: "The EMBED proof is verified: {} (at {:?})", compress_result.is_ok(), ...
New: "The EMBED proof is verified: {} (at {:?})", embed_result.is_ok(), ...
Reason: Use correct variable (embed_result).


Old: /// Returns if the instruction is a ecall instruction.
New: /// Returns whether the instruction is an ecall instruction.
Reason:  article ("an ecall").


Old: // the add constraint enforces external rounds is even
New: // the add constraint enforces that external rounds are even
Reason: Correct grammatical structure.