### PR TITLE
fix: fix macro placement and improve code structure

### DIFF
--- a/examples/fibonacci/app/src/main.rs
+++ b/examples/fibonacci/app/src/main.rs
@@ -1,9 +1,10 @@
 #![no_main]
 
-pico_sdk::entrypoint!(main);
 use alloy_sol_types::SolValue;
 use fibonacci_lib::{fibonacci, PublicValuesStruct};
 use pico_sdk::io::{commit_bytes, read_as};
+
+pico_sdk::entrypoint!(main);
 
 pub fn main() {
     // Read inputs `n` from the environment


### PR DESCRIPTION
This pull request refactors the code by moving the `pico_sdk::entrypoint!(main);` macro to the correct location after the import statements.
In Rust, the order of declarations is important, and macros such as `entrypoint!` should be declared after all imports to follow the standard coding conventions and improve code readability.