### PR TITLE
Fix Grammar & Variable Name Consistency

### DIFF
--- a/examples/fibonacci/prover/src/main.rs
+++ b/examples/fibonacci/prover/src/main.rs
@@ -40,7 +40,7 @@ fn verify_public_values(n: u32, public_values: &PublicValuesStruct) {
     // Compute Fibonacci values locally
     let (result_a, result_b) = fibonacci(0, 1, n);
 
-    // Assert that the computed values match the public values
+    // Ensure that the computed values match the public values
     assert_eq!(result_a, public_values.a, "Mismatch in value 'a'");
     assert_eq!(result_b, public_values.b, "Mismatch in value 'b'");
 }

--- a/gnark/babybear_verifier/verifier_test.go
+++ b/gnark/babybear_verifier/verifier_test.go
@@ -37,7 +37,7 @@ func TestSetupVerifierCircuit(t *testing.T) {
 	os.Setenv("CONSTRAINTS_JSON", "./constraints.json")
 	os.Setenv("GROTH16", "1")
 
-	circuit, assigment := doSolve(assert)
+	circuit, assignment := doSolve(assert)
 
 	doSetUp(assert, circuit, assigment)
 }
@@ -69,7 +69,7 @@ func doSetUp(assert *test.Assert, circuit *Circuit, assigment *Circuit) {
 
 	ccs, err := frontend.Compile(ecc.BN254.ScalarField(), r1cs.NewBuilder, circuit)
 	assert.NoError(err)
-	fmt.Printf("ccs: %d \n", ccs.GetNbConstraints())
+	fmt.Printf("ccs: %v\n", ccs.GetNbConstraints())
 
 	pk, vk, err := groth16.Setup(ccs)
 	if err != nil {


### PR DESCRIPTION
Reason: "Ensure" is clearer and more natural in this context.
assigment → assignment

