### PR TITLE
fix: small update for `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-ffi"
-version = "1.0.1"
+version = "1.1.2"
 dependencies = [
  "p3-baby-bear 0.1.0",
  "p3-field 0.1.0",
@@ -3128,7 +3128,7 @@ dependencies = [
 
 [[package]]
 name = "pico-cli"
-version = "1.0.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "pico-patch-libs"
-version = "1.0.1"
+version = "1.1.2"
 dependencies = [
  "bincode",
  "serde",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "pico-perf"
-version = "1.0.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "pico-scripts"
-version = "1.0.1"
+version = "1.1.2"
 dependencies = [
  "bincode",
  "clap",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "pico-sdk"
-version = "1.0.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "pico-vm"
-version = "1.0.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "arrayref",


### PR DESCRIPTION
### Summary

fix CI error:
https://github.com/brevis-network/pico/actions/runs/14761356339/job/41789805337?pr=19