### PR TITLE
fix: correct "assigment" typo to "assignment" across codebase

### DIFF
--- a/gnark/babybear_verifier/verifier_test.go
+++ b/gnark/babybear_verifier/verifier_test.go
@@ -3,6 +3,9 @@ package babybear_verifier
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/brevis-network/pico/gnark/utils"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
@@ -14,8 +17,6 @@ import (
 	"github.com/labstack/gommon/log"
 	"github.com/rs/zerolog"
 	"golang.org/x/crypto/sha3"
-	"os"
-	"testing"
 )
 
 func TestSolveVerifierCircuit(t *testing.T) {
@@ -37,12 +38,12 @@ func TestSetupVerifierCircuit(t *testing.T) {
 	os.Setenv("CONSTRAINTS_JSON", "./constraints.json")
 	os.Setenv("GROTH16", "1")
 
-	circuit, assigment := doSolve(assert)
+	circuit, assignment := doSolve(assert)
 
-	doSetUp(assert, circuit, assigment)
+	doSetUp(assert, circuit, assignment)
 }
 
-func doSolve(assert *test.Assert) (circuit *Circuit, assigment *Circuit) {
+func doSolve(assert *test.Assert) (circuit *Circuit, assignment *Circuit) {
 	data, err := os.ReadFile("./groth16_witness.json")
 	assert.NoError(err)
 
@@ -50,18 +51,18 @@ func doSolve(assert *test.Assert) (circuit *Circuit, assigment *Circuit) {
 	var inputs utils.WitnessInput
 	err = json.Unmarshal(data, &inputs)
 	assert.NoError(err)
-	assigment = NewCircuit(inputs)
+	assignment = NewCircuit(inputs)
 	circuit = NewCircuit(inputs)
 
-	err = test.IsSolved(circuit, assigment, ecc.BN254.ScalarField())
+	err = test.IsSolved(circuit, assignment, ecc.BN254.ScalarField())
 	assert.NoError(err)
 	fmt.Println("solve done")
 
-	return circuit, assigment
+	return circuit, assignment
 }
 
-func doSetUp(assert *test.Assert, circuit *Circuit, assigment *Circuit) {
-	fullWitness, err := frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+func doSetUp(assert *test.Assert, circuit *Circuit, assignment *Circuit) {
+	fullWitness, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 	assert.NoError(err)
 	pubWitness, err := fullWitness.Public()
 	assert.NoError(err)

--- a/gnark/koalabear_verifier/verifier_test.go
+++ b/gnark/koalabear_verifier/verifier_test.go
@@ -3,6 +3,10 @@ package koalabear_verifier
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+	"testing"
+
 	"github.com/brevis-network/pico/gnark/utils"
 	"github.com/consensys/gnark-crypto/ecc"
 	"github.com/consensys/gnark/backend"
@@ -13,9 +17,6 @@ import (
 	"github.com/consensys/gnark/test"
 	"github.com/rs/zerolog"
 	"golang.org/x/crypto/sha3"
-	"log"
-	"os"
-	"testing"
 )
 
 func TestSolveVerifierCircuit(t *testing.T) {
@@ -38,12 +39,12 @@ func TestSetupVerifierCircuit(t *testing.T) {
 	os.Setenv("CONSTRAINTS_JSON", "./constraints.json")
 	os.Setenv("GROTH16", "1")
 
-	circuit, assigment := doSolve(assert)
+	circuit, assignment := doSolve(assert)
 
-	doSetUp(assert, circuit, assigment)
+	doSetUp(assert, circuit, assignment)
 }
 
-func doSolve(assert *test.Assert) (circuit *Circuit, assigment *Circuit) {
+func doSolve(assert *test.Assert) (circuit *Circuit, assignment *Circuit) {
 	data, err := os.ReadFile("./groth16_witness.json")
 	assert.NoError(err)
 
@@ -51,18 +52,18 @@ func doSolve(assert *test.Assert) (circuit *Circuit, assigment *Circuit) {
 	var inputs utils.WitnessInput
 	err = json.Unmarshal(data, &inputs)
 	assert.NoError(err)
-	assigment = NewCircuit(inputs)
+	assignment = NewCircuit(inputs)
 	circuit = NewCircuit(inputs)
 
-	err = test.IsSolved(circuit, assigment, ecc.BN254.ScalarField())
+	err = test.IsSolved(circuit, assignment, ecc.BN254.ScalarField())
 	assert.NoError(err)
 	fmt.Println("solve done")
 
-	return circuit, assigment
+	return circuit, assignment
 }
 
-func doSetUp(assert *test.Assert, circuit *Circuit, assigment *Circuit) {
-	fullWitness, err := frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+func doSetUp(assert *test.Assert, circuit *Circuit, assignment *Circuit) {
+	fullWitness, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 	assert.NoError(err)
 	pubWitness, err := fullWitness.Public()
 	assert.NoError(err)

--- a/gnark/sdk/babybear_cmd.go
+++ b/gnark/sdk/babybear_cmd.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/brevis-network/pico/gnark/babybear_verifier"
 	"github.com/brevis-network/pico/gnark/utils"
 	"github.com/consensys/gnark-crypto/ecc"
@@ -13,7 +15,6 @@ import (
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/test"
 	"golang.org/x/crypto/sha3"
-	"os"
 )
 
 func BabyBearCmd(cmd string) (err error) {
@@ -61,7 +62,7 @@ func BabyBearCmd(cmd string) (err error) {
 	return
 }
 
-func DoBabyBearSolve() (circuit *babybear_verifier.Circuit, assigment *babybear_verifier.Circuit, err error) {
+func DoBabyBearSolve() (circuit *babybear_verifier.Circuit, assignment *babybear_verifier.Circuit, err error) {
 	witnessFile := os.Getenv("WITNESS_JSON")
 
 	data, err := os.ReadFile(witnessFile)
@@ -74,24 +75,24 @@ func DoBabyBearSolve() (circuit *babybear_verifier.Circuit, assigment *babybear_
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse witness json: %v\n", err)
 	}
-	assigment = babybear_verifier.NewCircuit(inputs)
+	assignment = babybear_verifier.NewCircuit(inputs)
 	circuit = babybear_verifier.NewCircuit(inputs)
 
-	err = test.IsSolved(circuit, assigment, ecc.BN254.ScalarField())
+	err = test.IsSolved(circuit, assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to solve: %v\n", err)
 	}
 	fmt.Println("solved with success")
 
-	return circuit, assigment, nil
+	return circuit, assignment, nil
 }
 
 func BabyBearSetup() error {
-	circuit, assigment, err := DoBabyBearSolve()
+	circuit, assignment, err := DoBabyBearSolve()
 	if err != nil {
 		return fmt.Errorf("fail to solve: %v\n", err)
 	}
-	fullWitness, err := frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+	fullWitness, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return fmt.Errorf("fail to gen full witness: %v", err)
 	}
@@ -166,15 +167,15 @@ func BabyBearProve() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse witness json: %v", err)
 	}
-	assigment := babybear_verifier.NewCircuit(inputs)
+	assignment := babybear_verifier.NewCircuit(inputs)
 	circuit := babybear_verifier.NewCircuit(inputs)
 
-	err = test.IsSolved(circuit, assigment, ecc.BN254.ScalarField())
+	err = test.IsSolved(circuit, assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return fmt.Errorf("failed to solve: %v", err)
 	}
 
-	fullWitness, err := frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+	fullWitness, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return fmt.Errorf("failed to get full witness: %v", err)
 	}

--- a/gnark/sdk/koalabear_cmd.go
+++ b/gnark/sdk/koalabear_cmd.go
@@ -3,6 +3,8 @@ package sdk
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/brevis-network/pico/gnark/koalabear_verifier"
 	"github.com/brevis-network/pico/gnark/utils"
 	"github.com/consensys/gnark-crypto/ecc"
@@ -13,7 +15,6 @@ import (
 	"github.com/consensys/gnark/frontend/cs/r1cs"
 	"github.com/consensys/gnark/test"
 	"golang.org/x/crypto/sha3"
-	"os"
 )
 
 func KoalaBearCmd(cmd string) (err error) {
@@ -61,7 +62,7 @@ func KoalaBearCmd(cmd string) (err error) {
 	return
 }
 
-func DoKoalaBearSolve() (circuit *koalabear_verifier.Circuit, assigment *koalabear_verifier.Circuit, err error) {
+func DoKoalaBearSolve() (circuit *koalabear_verifier.Circuit, assignment *koalabear_verifier.Circuit, err error) {
 	witnessFile := os.Getenv("WITNESS_JSON")
 
 	data, err := os.ReadFile(witnessFile)
@@ -74,24 +75,24 @@ func DoKoalaBearSolve() (circuit *koalabear_verifier.Circuit, assigment *koalabe
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse witness json: %v\n", err)
 	}
-	assigment = koalabear_verifier.NewCircuit(inputs)
+	assignment = koalabear_verifier.NewCircuit(inputs)
 	circuit = koalabear_verifier.NewCircuit(inputs)
 
-	err = test.IsSolved(circuit, assigment, ecc.BN254.ScalarField())
+	err = test.IsSolved(circuit, assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to solve: %v\n", err)
 	}
 	fmt.Println("solved with success")
 
-	return circuit, assigment, nil
+	return circuit, assignment, nil
 }
 
 func KoalaBearSetup() error {
-	circuit, assigment, err := DoKoalaBearSolve()
+	circuit, assignment, err := DoKoalaBearSolve()
 	if err != nil {
 		return fmt.Errorf("fail to solve: %v\n", err)
 	}
-	fullWitness, err := frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+	fullWitness, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return fmt.Errorf("fail to gen full witness: %v", err)
 	}
@@ -167,15 +168,15 @@ func KoalaBearProve() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse witness json: %v", err)
 	}
-	assigment := koalabear_verifier.NewCircuit(inputs)
+	assignment := koalabear_verifier.NewCircuit(inputs)
 	circuit := koalabear_verifier.NewCircuit(inputs)
 
-	err = test.IsSolved(circuit, assigment, ecc.BN254.ScalarField())
+	err = test.IsSolved(circuit, assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return fmt.Errorf("failed to solve: %v", err)
 	}
 
-	fullWitness, err := frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+	fullWitness, err := frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 	if err != nil {
 		return fmt.Errorf("failed to get full witness: %v", err)
 	}

--- a/gnark/server/main/main.go
+++ b/gnark/server/main/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+
 	"github.com/brevis-network/pico/gnark/babybear_verifier"
 	"github.com/brevis-network/pico/gnark/koalabear_verifier"
 	"github.com/brevis-network/pico/gnark/utils"
@@ -16,9 +17,10 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/labstack/echo"
 
-	"golang.org/x/crypto/sha3"
 	"net/http"
 	"sync"
+
+	"golang.org/x/crypto/sha3"
 )
 
 var (
@@ -110,9 +112,9 @@ func Prove(c echo.Context) error {
 
 func GetWitnessFromHex(inputs utils.WitnessInput) (fullWitness witness.Witness, pubWitness witness.Witness, err error) {
 	if *field == "kb" {
-		assigment := koalabear_verifier.NewCircuit(inputs)
+		assignment := koalabear_verifier.NewCircuit(inputs)
 
-		fullWitness, err = frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+		fullWitness, err = frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 		if err != nil {
 			return
 		}
@@ -121,9 +123,9 @@ func GetWitnessFromHex(inputs utils.WitnessInput) (fullWitness witness.Witness, 
 			return
 		}
 	} else if *field == "bb" {
-		assigment := babybear_verifier.NewCircuit(inputs)
+		assignment := babybear_verifier.NewCircuit(inputs)
 
-		fullWitness, err = frontend.NewWitness(assigment, ecc.BN254.ScalarField())
+		fullWitness, err = frontend.NewWitness(assignment, ecc.BN254.ScalarField())
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Changes:
- Replace "assigment" with "assignment" in variable declarations
- Update function parameter names and return values
- Maintain consistent naming across all affected files

Files modified:
- gnark/koalabear_verifier/verifier_test.go
- gnark/sdk/koalabear_cmd.go
- gnark/sdk/babybear_cmd.go
- gnark/server/main/main.go
- gnark/babybear_verifier/verifier_test.go

No functional changes, only spelling correction.