### PR TITLE
Update outdated dependencies in the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ elf = "0.7.4"
 elliptic-curve = "0.13.8"
 env_logger = "0.11.6"
 eyre = "0.6.12"
-ff = { version = "0.13", features = ["derive", "derive_bits"] }
+ff = { version = "0.13.0", features = ["derive", "derive_bits"] }
 generic-array = { version = "1.1.0", features = ["alloc", "serde"] }
 halo2curves = "0.7.0"
 hashbrown = { version = "0.14.5", features = ["serde", "inline-more"] }
@@ -143,7 +143,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 strum_macros = "0.26.4"
 syn = { version = "1.0", features = ["full"] }
 sysinfo = "0.30.13"
-thiserror = "1.0.63"
+thiserror = "2.0.11"
 tikv-jemallocator = "0.6"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tracing = "0.1.40"
@@ -152,3 +152,7 @@ tracing-subscriber = { version = "0.3.18", features = ["std", "env-filter"] }
 typenum = "1.17.0"
 vec_map = "0.8.2"
 zkhash = "0.2.0"
+libm = "0.2.15"
+wit-bindgen-rt = "0.39.0"
+getrandom = "0.3.3"
+wasi = "0.14.2+wasi-0.2.4"


### PR DESCRIPTION
1. Updated existing dependencies:
   - ff: 0.13 -> 0.13.0
   - thiserror: 1.0.63 -> 2.0.11

2. Added explicit workspace dependencies for packages used by multiple workspace members:
   - libm: 0.2.15 (was 0.2.11)
   - wit-bindgen-rt: 0.39.0 (was 0.33.0)
   - getrandom: 0.3.3 (was 0.3.1)
   - wasi: 0.14.2+wasi-0.2.4 (was 0.13.3+wasi-0.2.2)

These updates are based on the results from running `cargo outdated` command on the project, which showed these dependencies as having newer versions available.

The dependencies were updated to ensure we're using the latest versions with bug fixes and improvements, while maintaining compatibility with the project.