### PR TITLE
fix: padding in Compress to match Convert and Combine

### DIFF
--- a/scripts/src/bin/build_vk_map.rs
+++ b/scripts/src/bin/build_vk_map.rs
@@ -151,7 +151,7 @@ macro_rules! define_vk_digest_from_shape {
                             &stdin_with_vk,
                         );
                     let compress_pad_shape = RecursionChipType::<$F>::compress_shape();
-                    program_with_vk.shape = Some(compress_pad_shape);
+                    recursion_shape_config.padding_shape(&mut program_with_vk);
                     let (_pk, vk) = machine.setup_keys(&program_with_vk);
                     vk.hash_field()
                 }


### PR DESCRIPTION
Convert and Combine use `recursion_shape_config.padding_shape` to apply padding properly.
Compress was setting the shape manually, which can cause issues with data consistency and compatibility.

this updates Compress to use the same padding method, keeping things consistent and safer across the board.
plus, it makes future changes easier since padding logic stays in one place.
