### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ elliptic-curve = "0.13.8"
 env_logger = "0.11.6"
 eyre = "0.6.12"
 ff = { version = "0.13", features = ["derive", "derive_bits"] }
+generic-array = "1"
 halo2curves = "0.7.0"
 hashbrown = { version = "0.14.5", features = ["serde", "inline-more"] }
 hex = "0.4.3"


### PR DESCRIPTION
Specify generic-array 1.x version as from_slice is otherwise deprecated.