### PR TITLE
error[E0658]: cannot call conditionally-const operator in constant functions

### DIFF
--- a/vm/src/machine/field.rs
+++ b/vm/src/machine/field.rs
@@ -86,11 +86,15 @@ pub const fn same_field<T: Any, F: Field + BinomiallyExtendable<D>, const D: usi
     unsafe {
        let typ = std::intrinsics::type_id::<T>();
         
-        typ == FIELD
-            || typ == EXPR
-            || typ == PACKING
-            || typ == BINOMIAL
-            || typ == EXT
-            || typ == FELT
+        typ_eq(typ, FIELD)
+            || typ_eq(typ, EXPR)
+            || typ_eq(typ, PACKING)
+            || typ_eq(typ, BINOMIAL)
+            || typ_eq(typ, EXT)
+            || typ_eq(typ, FELT)
     }
+}
+
+const fn typ_eq(a: usize, b: usize) -> bool {
+    a == b
 }


### PR DESCRIPTION
Define type IDs as const outside of same_field so they may be used within.