### PR TITLE
feat: Implement `prove_evm_with_deferred()` method in Pico SDK To Generate EVM-friendly Aggregated Proofs

### DIFF
--- a/sdk/sdk/src/client.rs
+++ b/sdk/sdk/src/client.rs
@@ -286,6 +286,58 @@ macro_rules! create_sdk_prove_client {
                 generate_contract_inputs::<$fc>(output.clone())?;
                 Ok(())
             }
+
+            /// Prove and generate gnark proof with deferred proof support (for aggregation).
+            /// Use this instead of prove_evm when your program calls verify_pico_proof.
+            pub fn prove_evm_with_deferred(
+                &self,
+                stdin: EmulatorStdinBuilder<Vec<u8>, $sc>,
+                need_setup: bool,
+                output: impl AsRef<Path>,
+                field_type: &str,
+            ) -> Result<(), Error> {
+                let output = output.as_ref();
+                let (riscv_proof, combine_proof) = self.prove_combine(stdin)?;
+
+                // Continue the proving chain: compress then embed
+                let riscv_vk = self.riscv_vk();
+                let compress_proof = self.compress.prove(combine_proof);
+                if !self.compress.verify(&compress_proof, riscv_vk) {
+                    return Err(Error::msg("verify compress proof failed"));
+                }
+
+                let embed_proof = self.embed.prove(compress_proof);
+                if !self.embed.verify(&embed_proof, riscv_vk) {
+                    return Err(Error::msg("verify embed proof failed"));
+                }
+
+                self.write_onchain_data(output, &riscv_proof, &embed_proof)?;
+                let field_name = match field_type {
+                    "kb" => {
+                        "koalabear"
+                    }
+                    "bb" => {
+                        "babybear"
+                    }
+                    _ => {
+                        return Err(Error::msg("field type not supported"));
+                    }
+                };
+                if need_setup {
+                    let mut setup_cmd = Command::new("sh");
+                    setup_cmd.arg("-c")
+                        .arg(format!("docker run --rm -v {}:/data brevishub/pico_gnark_cli:1.1 /pico_gnark_cli -field {} -cmd setup -sol ./data/Groth16Verifier.sol", output.display(), field_name));
+                    execute_command(setup_cmd);
+                }
+
+                let mut prove_cmd = Command::new("sh");
+                prove_cmd.arg("-c")
+                    .arg(format!("docker run --rm -v {}:/data brevishub/pico_gnark_cli:1.1 /pico_gnark_cli -field {} -cmd prove -sol ./data/Groth16Verifier.sol", output.display(), field_name));
+
+                execute_command(prove_cmd);
+                generate_contract_inputs::<$fc>(output.clone())?;
+                Ok(())
+            }
         }
     };
 }


### PR DESCRIPTION
The `prove_evm()` method would not work for Aggregator programs, i.e. any guest programs that batch and verify existing proofs with `verify_pico_proof()` will fail. This is because it internally calls `self.prove()` which in turn [discards all deferred proofs](https://github.com/brevis-network/pico/blob/b52a89e4551b3f28086f7aae49505631845bf961/sdk/sdk/src/client.rs#L127) that is written to `stdin` by calling `write_pico_proof()` for proof aggregation on the host-side. 

This as a result, causes the `COMBINE` phase of the proving chain to fail for the Aggregator.

In this PR, I implemented a `prove_evm_with_deferred()` method that calls `prove_combine()` instead of `prove()`. Once a combined proof has returned, it would continue along the proving chain ( COMPRESS -> EMBED -> ONCHAIN ) to generate a proof that is verifiable on-chain.

Host side programs that want to generate EVM-friendly aggregated proofs, would then simply call `prove_evm_with_deferred()`.

I have a working demo of the Pico zkVM integration with our [AWS Nitro Attestation](https://github.com/automata-network/aws-nitro-enclave-attestation/blob/6cda3f23116f304b131602f6253adc2019587c31/crates/prover/src/program_pico.rs#L82-L107), which generates aggregated proof of verification for multiple Nitro Enclave Attestations.

I look forward to hearing your feedback! :)