### PR TITLE
fix: fix `pico-cli` install error

### DIFF
--- a/sdk/cli/Cargo.toml
+++ b/sdk/cli/Cargo.toml
@@ -21,7 +21,7 @@ hex.workspace = true
 pico-sdk.workspace = true
 log.workspace = true
 env_logger.workspace = true
-pico-vm.workspace = true
+pico-vm = { workspace = true, default-features = false, features = ["rayon", "nightly-features"] }
 yansi = "1.0.1"
 cargo_metadata = "0.18.1"
 serde_json.workspace = true


### PR DESCRIPTION
### Summary

Fix the error when install `pico-cli`:
```
> cargo +nightly-2025-08-04 install --git https://github.com/brevis-network/pico pico-cli

error: use of deprecated associated function `elliptic_curve::generic_array::GenericArray::<T, N>::from_slice`: please upgrade to generic-array 1.x
  --> vm/src/emulator/riscv/hook/ecrecover.rs:48:62
   |
48 |         let nqr_field = FieldElement::from_bytes(FieldBytes::from_slice(&NQR)).unwrap();
   |                                                              ^^^^^^^^^^
   |
note: the lint level is defined here
  --> vm/src/lib.rs:2:38
   |
 2 | #![cfg_attr(feature = "strict", deny(warnings))]
   |                                      ^^^^^^^^
   = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
```