### PR TITLE
fix: temporarily allow deprecated dependencies when installs from the git URL

### DIFF
--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -1,5 +1,7 @@
 // lock deny(warnings) behind strict feature
 #![cfg_attr(feature = "strict", deny(warnings))]
+// allow deprecated dependencies when installs from the git URL
+#![allow(deprecated)]
 #![allow(clippy::module_inception)]
 #![allow(clippy::needless_range_loop)]
 #![allow(incomplete_features)]


### PR DESCRIPTION
### Summary

Fix the error when install CLI from the git URL:
```
cargo +nightly-2025-08-04 install --git https://github.com/brevis-network/pico pico-cli

error: use of deprecated associated function `elliptic_curve::generic_array::GenericArray::<T, N>::from_slice`: please upgrade to generic-array 1.x
  --> vm/src/emulator/riscv/hook/ecrecover.rs:48:62
   |
48 |         let nqr_field = FieldElement::from_bytes(FieldBytes::from_slice(&NQR)).unwrap();
   |                                                              ^^^^^^^^^^
   |
note: the lint level is defined here
  --> vm/src/lib.rs:2:38
   |
 2 | #![cfg_attr(feature = "strict", deny(warnings))]
```

Will upgrade `generic-array` related dependencies with precompiles.