### PR TITLE
fix: restore vk verification check in prove_evm

### DIFF
--- a/sdk/sdk/src/client.rs
+++ b/sdk/sdk/src/client.rs
@@ -255,10 +255,10 @@ macro_rules! create_sdk_prove_client {
                 field_type: &str,
             ) -> Result<(), Error> {
                 let output = output.as_ref();
-                // let vk_verification = vk_verification_enabled();
-                // if !vk_verification {
-                //     return Err(Error::msg("VK_VERIFICATION must be set to true in evm proof"));
-                // }
+                let vk_verification = vk_verification_enabled();
+                if !vk_verification {
+                    return Err(Error::msg("VK_VERIFICATION must be set to true in evm proof"));
+                }
                 let (riscv_proof, embed_proof) = self.prove(stdin)?;
                 self.write_onchain_data(output, &riscv_proof, &embed_proof)?;
                 let field_name = match field_type {


### PR DESCRIPTION
The VK verification guard in prove_evm was commented out 9 months ago during a benchmarking refactor and never restored. This check is required for EVM proofs to ensure the verifying key is valid before generating onchain proof data. Re-enable the check to prevent invalid proofs from reaching the EVM verifier.