### PR TITLE
fix(vm): bind memory timestamps and harden ecrecover hooks

### DIFF
--- a/aot-runtime/src/hook.rs
+++ b/aot-runtime/src/hook.rs
@@ -1,12 +1,14 @@
 use crate::emulator::AotEmulatorCore;
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use hashbrown::HashMap;
-use k256::{elliptic_curve::ff::PrimeField, FieldBytes, FieldElement, Scalar as K256Scalar};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
-use pico_vm::chips::gadgets::{
-    curves::{edwards::ed25519::decompress, weierstrass::bls381::Bls381BaseField},
-    utils::field_params::FieldParameters,
+use pico_vm::{
+    chips::gadgets::{
+        curves::{edwards::ed25519::decompress, weierstrass::bls381::Bls381BaseField},
+        utils::field_params::FieldParameters,
+    },
+    emulator::riscv::hook::ecrecover_bytes,
 };
 
 pub type Hook = fn(&AotEmulatorCore, &[u8]) -> Vec<Vec<u8>>;
@@ -30,12 +32,6 @@ pub fn default_hook_map() -> HashMap<u32, Hook> {
     HashMap::from_iter(hooks)
 }
 
-const NQR: [u8; 32] = {
-    let mut nqr = [0; 32];
-    nqr[31] = 3;
-    nqr
-};
-
 const NQR_BLS12_381: [u8; 48] = {
     let mut nqr = [0; 48];
     nqr[47] = 2;
@@ -50,45 +46,7 @@ fn pad_to_be(val: &BigUint, len: usize) -> Vec<u8> {
 }
 
 pub fn ecrecover(_: &AotEmulatorCore, buf: &[u8]) -> Vec<Vec<u8>> {
-    if buf.len() != 65 {
-        return vec![vec![0]];
-    }
-
-    let r_is_y_odd = buf[0] & 0b1000_0000 != 0;
-
-    let r_bytes: [u8; 32] = buf[1..33].try_into().unwrap();
-    let alpha_bytes: [u8; 32] = buf[33..65].try_into().unwrap();
-
-    let r = FieldElement::from_bytes(&FieldBytes::from(r_bytes)).unwrap();
-    let alpha = FieldElement::from_bytes(&FieldBytes::from(alpha_bytes)).unwrap();
-
-    if bool::from(r.is_zero()) || bool::from(alpha.is_zero()) {
-        return vec![vec![0]];
-    }
-
-    if let Some(mut y_coord) = alpha.sqrt().into_option().map(|y| y.normalize()) {
-        let r = K256Scalar::from_repr(r.to_bytes()).unwrap();
-        let r_inv = r.invert().expect("Non zero r scalar");
-
-        if r_is_y_odd != bool::from(y_coord.is_odd()) {
-            y_coord = y_coord.negate(1);
-            y_coord = y_coord.normalize();
-        }
-
-        vec![
-            vec![1],
-            y_coord.to_bytes().to_vec(),
-            r_inv.to_bytes().to_vec(),
-        ]
-    } else {
-        let nqr_field = FieldElement::from_bytes(&FieldBytes::from(NQR)).unwrap();
-        let qr = alpha * nqr_field;
-        let root = qr
-            .sqrt()
-            .expect("if alpha is not a square, then qr should be a square");
-
-        vec![vec![0], root.to_bytes().to_vec()]
-    }
+    ecrecover_bytes(buf)
 }
 
 #[must_use]

--- a/vm/src/chips/chips/riscv_cpu/constraints.rs
+++ b/vm/src/chips/chips/riscv_cpu/constraints.rs
@@ -76,6 +76,9 @@ where
             .chain(once(local.opcode_selector.is_sh))
             .chain(once(local.opcode_selector.is_sw))
             .chain(once(local.opcode_selector.is_sd))
+            // Bind the data-memory access to this CPU row's execution time.
+            .chain(once(local.chunk))
+            .chain(once(local.clk))
             .map(Into::into);
         // Memory lookup
         builder.looking(SymbolicLookup::new(

--- a/vm/src/chips/chips/riscv_cpu/tests.rs
+++ b/vm/src/chips/chips/riscv_cpu/tests.rs
@@ -1,6 +1,9 @@
 use crate::{
     chips::chips::riscv_cpu::CpuChip,
-    machine::{builder::PublicValuesBuilder, chip::ChipBehavior, folder::SymbolicConstraintFolder},
+    machine::{
+        builder::PublicValuesBuilder, chip::ChipBehavior, folder::SymbolicConstraintFolder,
+        lookup::LookupType,
+    },
 };
 use p3_air::{Air, BaseAir};
 use p3_koala_bear::KoalaBear;
@@ -16,4 +19,9 @@ fn test_cpu_chip_simple_eval() {
     assert_eq!(builder.num_constraints(), 217);
     assert_eq!(builder.public_values().len(), 119);
     assert_eq!(builder.num_lookups(), 35);
+
+    let (looking, _) = builder.lookups();
+    assert!(looking
+        .iter()
+        .any(|lookup| lookup.kind == LookupType::Memory && lookup.values.len() == 27));
 }

--- a/vm/src/chips/chips/riscv_memory/read_write/constraints.rs
+++ b/vm/src/chips/chips/riscv_memory/read_write/constraints.rs
@@ -63,6 +63,9 @@ where
                 .chain(once(local_memory_chip_value_cols.instruction.is_sh))
                 .chain(once(local_memory_chip_value_cols.instruction.is_sw))
                 .chain(once(local_memory_chip_value_cols.instruction.is_sd))
+                // Authenticate the memory row's time against the dispatching CPU row.
+                .chain(once(local_memory_chip_value_cols.chunk))
+                .chain(once(local_memory_chip_value_cols.clk))
                 .map(Into::into);
 
             builder.looked(SymbolicLookup::new(

--- a/vm/src/chips/chips/riscv_memory/read_write/tests.rs
+++ b/vm/src/chips/chips/riscv_memory/read_write/tests.rs
@@ -1,6 +1,9 @@
 use crate::{
     chips::chips::riscv_memory::read_write::MemoryReadWriteChip,
-    machine::{builder::PublicValuesBuilder, chip::ChipBehavior, folder::SymbolicConstraintFolder},
+    machine::{
+        builder::PublicValuesBuilder, chip::ChipBehavior, folder::SymbolicConstraintFolder,
+        lookup::LookupType,
+    },
 };
 use p3_air::{Air, BaseAir};
 use p3_koala_bear::KoalaBear;
@@ -16,4 +19,9 @@ fn test_memory_read_write_chip_simple_eval() {
     assert_eq!(builder.num_constraints(), 85);
     assert_eq!(builder.public_values().len(), 119);
     assert_eq!(builder.num_lookups(), 16);
+
+    let (_, looked) = builder.lookups();
+    assert!(looked
+        .iter()
+        .any(|lookup| lookup.kind == LookupType::Memory && lookup.values.len() == 27));
 }

--- a/vm/src/emulator/riscv/hook/ecrecover.rs
+++ b/vm/src/emulator/riscv/hook/ecrecover.rs
@@ -9,6 +9,13 @@ const NQR: [u8; 32] = {
 };
 
 pub fn ecrecover(_: &RiscvEmulator, buf: &[u8]) -> Vec<Vec<u8>> {
+    ecrecover_bytes(buf)
+}
+
+/// Executes the secp256k1 recovery hook without depending on an emulator instance.
+///
+/// Invalid guest encodings use the hook's ordinary failure response and never panic.
+pub fn ecrecover_bytes(buf: &[u8]) -> Vec<Vec<u8>> {
     // Early return if the buffer length is incorrect
     if buf.len() != 65 {
         return vec![vec![0]];
@@ -17,12 +24,24 @@ pub fn ecrecover(_: &RiscvEmulator, buf: &[u8]) -> Vec<Vec<u8>> {
     let r_is_y_odd = buf[0] & 0b1000_0000 != 0;
 
     // Directly convert slices to arrays without intermediate steps
-    let r_bytes: [u8; 32] = buf[1..33].try_into().unwrap();
-    let alpha_bytes: [u8; 32] = buf[33..65].try_into().unwrap();
+    let Ok(r_bytes): Result<[u8; 32], _> = buf[1..33].try_into() else {
+        return vec![vec![0]];
+    };
+    let Ok(alpha_bytes): Result<[u8; 32], _> = buf[33..65].try_into() else {
+        return vec![vec![0]];
+    };
 
     // Convert bytes to field elements
-    let r = FieldElement::from_bytes(&FieldBytes::from(r_bytes)).unwrap();
-    let alpha = FieldElement::from_bytes(&FieldBytes::from(alpha_bytes)).unwrap();
+    let Some(r) =
+        Option::<FieldElement>::from(FieldElement::from_bytes(&FieldBytes::from(r_bytes)))
+    else {
+        return vec![vec![0]];
+    };
+    let Some(alpha) =
+        Option::<FieldElement>::from(FieldElement::from_bytes(&FieldBytes::from(alpha_bytes)))
+    else {
+        return vec![vec![0]];
+    };
 
     // Early return if r or alpha is zero
     if bool::from(r.is_zero()) || bool::from(alpha.is_zero()) {
@@ -31,8 +50,12 @@ pub fn ecrecover(_: &RiscvEmulator, buf: &[u8]) -> Vec<Vec<u8>> {
 
     // Normalize the y-coordinate always to be consistent.
     if let Some(mut y_coord) = alpha.sqrt().into_option().map(|y| y.normalize()) {
-        let r = K256Scalar::from_repr(r.to_bytes()).unwrap();
-        let r_inv = r.invert().expect("Non zero r scalar");
+        let Some(r) = Option::<K256Scalar>::from(K256Scalar::from_repr(r.to_bytes())) else {
+            return vec![vec![0]];
+        };
+        let Some(r_inv) = Option::<K256Scalar>::from(r.invert()) else {
+            return vec![vec![0]];
+        };
 
         if r_is_y_odd != bool::from(y_coord.is_odd()) {
             y_coord = y_coord.negate(1);
@@ -52,5 +75,51 @@ pub fn ecrecover(_: &RiscvEmulator, buf: &[u8]) -> Vec<Vec<u8>> {
             .expect("if alpha is not a square, then qr should be a square");
 
         vec![vec![0], root.to_bytes().to_vec()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ecrecover_bytes;
+
+    const SCALAR_MODULUS: [u8; 32] = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c, 0xd0, 0x36,
+        0x41, 0x41,
+    ];
+
+    fn one() -> [u8; 32] {
+        let mut value = [0; 32];
+        value[31] = 1;
+        value
+    }
+
+    fn input(r: [u8; 32], alpha: [u8; 32]) -> [u8; 65] {
+        let mut input = [0; 65];
+        input[1..33].copy_from_slice(&r);
+        input[33..65].copy_from_slice(&alpha);
+        input
+    }
+
+    #[test]
+    fn rejects_invalid_guest_encodings_without_panicking() {
+        let failure = vec![vec![0]];
+
+        assert_eq!(ecrecover_bytes(&[]), failure);
+        assert_eq!(ecrecover_bytes(&input([0xff; 32], one())), failure);
+        assert_eq!(ecrecover_bytes(&input(one(), [0xff; 32])), failure);
+        assert_eq!(ecrecover_bytes(&input(SCALAR_MODULUS, one())), failure);
+        assert_eq!(ecrecover_bytes(&input([0; 32], one())), failure);
+        assert_eq!(ecrecover_bytes(&input(one(), [0; 32])), failure);
+    }
+
+    #[test]
+    fn accepts_canonical_nonzero_input() {
+        let output = ecrecover_bytes(&input(one(), one()));
+
+        assert_eq!(output.len(), 3);
+        assert_eq!(output[0], vec![1]);
+        assert_eq!(output[1].len(), 32);
+        assert_eq!(output[2], one());
     }
 }

--- a/vm/src/emulator/riscv/hook/mod.rs
+++ b/vm/src/emulator/riscv/hook/mod.rs
@@ -3,6 +3,8 @@ mod ecrecover;
 mod ed_decompress;
 mod fp;
 
+pub use ecrecover::ecrecover_bytes;
+
 use super::riscv_emulator::RiscvEmulator;
 use hashbrown::HashMap;
 


### PR DESCRIPTION
`MemoryReadWrite` rows currently match CPU load/store instructions without including `chunk` and `clk`, allowing the memory table to use an execution time different from the corresponding CPU row. This change appends `(chunk, clk)` to both sides of the lookup so each ordinary load/store transition is bound to the CPU row's constrained execution time.

The ECRecover hook currently assumes guest-provided field and scalar encodings are canonical and can panic while decoding or inverting invalid inputs. This change replaces those assumptions with checked conversions and returns the hook's existing failure response for invalid encodings. VM and AOT execution now share the same implementation so both paths apply identical validation.
