### PR TITLE
fix: carry the AOT factory glue in-crate instead of via examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,15 +231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "aot-common"
-version = "0.1.0"
-dependencies = [
- "pico-aot-dispatch",
- "pico-vm",
- "tracing",
-]
-
-[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,7 +3888,6 @@ name = "pico-perf"
 version = "2.1.0"
 dependencies = [
  "anyhow",
- "aot-common",
  "bincode",
  "clap",
  "log",
@@ -3906,6 +3896,7 @@ dependencies = [
  "p3-field 0.1.0",
  "p3-koala-bear",
  "p3-symmetric 0.1.0",
+ "pico-aot-dispatch",
  "pico-sdk",
  "pico-vm",
  "pprof",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-ffi"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "p3-baby-bear 0.1.0",
  "p3-field 0.1.0",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "pico-aot-runtime"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "pico-cli"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "pico-derive"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "pico-patch-libs"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "pico-perf"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3908,7 +3908,7 @@ dependencies = [
 
 [[package]]
 name = "pico-scripts"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bincode",
  "clap",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "pico-sdk"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3949,7 +3949,7 @@ dependencies = [
 
 [[package]]
 name = "pico-vm"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "arrayref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["derive", "vm", "aot-codegen", "aot-runtime", "sdk/*", "scripts", "gn
 resolver = "2"
 
 [workspace.package]
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 keywords = ["zkvm", "plonky3", "stark", "FRI"]

--- a/aot-codegen/src/compiler.rs
+++ b/aot-codegen/src/compiler.rs
@@ -53,11 +53,11 @@ fn run_table_word_u32(word_offset: u64) -> u32 {
 
 /// Emit the `pico-aot-runtime = { ... }` line for a generated Cargo.toml.
 ///
-/// Defaults to a relative `path = "{default_path}"` so the brevis-vm
-/// in-tree layout keeps working. When `PICO_AOT_RUNTIME_SPEC` is set and
+/// Defaults to a relative `path = "{default_path}"` so the in-tree layout
+/// keeps working. When `PICO_AOT_RUNTIME_SPEC` is set and
 /// non-empty, its value is inlined as the dep body verbatim, letting
-/// downstream consumers generate `aot-generated/` outside the brevis-vm
-/// workspace (e.g. at a template's root) and wire the runtime via git.
+/// downstream consumers generate `aot-generated/` outside this workspace
+/// (e.g. at a template's root) and wire the runtime via git.
 ///
 /// Example:
 ///   PICO_AOT_RUNTIME_SPEC='git = "https://github.com/brevis-network/pico", branch = "X"'

--- a/aot-runtime/src/emulator/memory.rs
+++ b/aot-runtime/src/emulator/memory.rs
@@ -52,7 +52,7 @@ impl AotEmulatorCore {
     #[inline(always)]
     fn account_memory_access(&mut self, _addr: u64) {
         // NOTE: Simple-mode tracks unique addresses via chunk_split_state.memory_access_addrs.
-        // AOT must mirror this to keep chunk boundary detection consistent with gpu-base.
+        // AOT must mirror this to keep chunk boundary detection consistent.
         if self.in_syscall() {
             self.chunk_split_state.add_syscall_memory_events(1);
         } else {

--- a/perf/Cargo.toml
+++ b/perf/Cargo.toml
@@ -21,16 +21,16 @@ tracing.workspace = true
 strum.workspace = true
 pprof = { version = "0.15", features = ["flamegraph", "protobuf", "protobuf-codec"] }
 
-# Optional AOT glue (enabled by the `aot` feature). `aot-common` provides
-# register_with_vm(), which registers the AOT factory backed by the generated
-# `pico-aot-dispatch` crate (repo-root `aot-generated`, produced by generate_crates).
-aot-common = { path = "../examples/aot_common", optional = true }
+# Optional AOT glue (enabled by the `aot` feature). The factory lives in
+# `src/aot_glue.rs` and is backed by the generated `pico-aot-dispatch` crate
+# (repo-root `aot-generated`, produced by generate_crates).
+pico-aot-dispatch = { path = "../aot-generated", optional = true }
 
 [features]
 jemalloc = ["pico-vm/jemalloc"]
 nightly-features = ["pico-vm/nightly-features"]
 # AOT-capable prove path: pico-vm's aot-emulator + the AOT dispatch/factory.
-aot = ["pico-vm/aot-emulator", "dep:aot-common", "aot-common/aot"]
+aot = ["pico-vm/aot-emulator", "dep:pico-aot-dispatch"]
 
 [[bin]]
 name = "bench"

--- a/perf/bench_apps/Cargo.lock
+++ b/perf/bench_apps/Cargo.lock
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "pico-derive"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "pico-patch-libs"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "pico-sdk"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "pico-vm"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "arrayref",

--- a/perf/src/aot_glue.rs
+++ b/perf/src/aot_glue.rs
@@ -1,0 +1,113 @@
+//! AOT factory glue for `bench --aot`.
+//!
+//! Registers an `AotSnapshotEmulator` factory backed by the generated
+//! `pico-aot-dispatch` crate (repo-root `aot-generated`, produced by
+//! `generate_crates`).
+//!
+//! Each consumer of the AOT prove path carries its own copy of this glue,
+//! because the factory has to name the *generated* dispatch crate, and that
+//! crate is regenerated per guest ELF. `cargo pico new` ships the same file as
+//! `prover/src/aot_glue.rs` for downstream projects, and the AOT examples have
+//! their own copy.
+
+use std::sync::Arc;
+
+use pico_aot_dispatch::AotEmulatorCore;
+use pico_vm::{
+    compiler::riscv::program::Program,
+    emulator::{
+        aot::{register_aot_factory, AotSnapshotEmulator},
+        opts::EmulatorOpts,
+        riscv::{
+            chunk_split::ChunkSplitConfig, riscv_emulator::EmulationError,
+            state::RiscvEmulationState,
+        },
+    },
+    machine::report::EmulationReport,
+};
+
+fn next_state_batch_impl(
+    emu: &mut AotEmulatorCore,
+    opts: EmulatorOpts,
+) -> Result<(RiscvEmulationState, EmulationReport), String> {
+    let start_chunk = emu.current_chunk;
+    let start_cycle = emu.insn_count;
+
+    emu.batch_chunk_target = opts.chunk_batch_size;
+    emu.batch_chunks_emulated = 0;
+    emu.batch_stop = false;
+    emu.chunk_split_config =
+        ChunkSplitConfig::for_chunk_size(opts.chunk_size, emu.max_syscall_cycles);
+
+    emu.save_batch_start_state();
+    let mut snapshot = emu.build_snapshot_state();
+
+    pico_aot_dispatch::run_aot(emu)?;
+
+    let done = emu.pc == 0
+        || emu.pc.wrapping_sub(emu.program_pc_base()).wrapping_div(4) >= emu.program_len() as u64;
+
+    if !done {
+        emu.current_batch = emu.current_batch.wrapping_add(1);
+    }
+
+    if done {
+        emu.fill_snapshot_memory_full_prestate(&mut snapshot);
+    } else {
+        emu.fill_snapshot_memory_delta(&mut snapshot);
+    }
+
+    let report = EmulationReport {
+        current_cycle: emu.insn_count,
+        start_chunk,
+        done,
+        cycle_tracker: None,
+        host_cycle_estimator: None,
+    };
+
+    if !done && emu.insn_count == start_cycle && emu.batch_chunk_target > 0 {
+        return Err("AOT next_state_batch made no progress (possible yield bug)".to_string());
+    }
+
+    Ok((snapshot, report))
+}
+
+struct VmAotAdapter {
+    core: AotEmulatorCore,
+    opts: EmulatorOpts,
+}
+
+impl AotSnapshotEmulator for VmAotAdapter {
+    fn next_state_batch(
+        &mut self,
+    ) -> Result<(RiscvEmulationState, EmulationReport), EmulationError> {
+        next_state_batch_impl(&mut self.core, self.opts).map_err(|s| {
+            tracing::error!(error = %s, "AOT adapter error");
+            EmulationError::Aot(s)
+        })
+    }
+
+    fn cycles(&self) -> u64 {
+        self.core.insn_count
+    }
+
+    fn get_pv_stream(&mut self) -> Vec<u8> {
+        core::mem::take(&mut self.core.public_values_stream)
+    }
+}
+
+fn aot_factory(
+    program: Arc<Program>,
+    input_stream: Vec<Vec<u8>>,
+    opts: EmulatorOpts,
+) -> Box<dyn AotSnapshotEmulator> {
+    Box::new(VmAotAdapter {
+        core: AotEmulatorCore::new(program, input_stream),
+        opts,
+    })
+}
+
+/// Register the AOT factory with the VM. Call once, before proving.
+pub fn register_with_vm() {
+    register_aot_factory(aot_factory);
+}

--- a/perf/src/bin/bench.rs
+++ b/perf/src/bin/bench.rs
@@ -571,7 +571,7 @@ fn main() -> Result<()> {
     if args.aot {
         #[cfg(feature = "aot")]
         {
-            aot_common::register_with_vm();
+            pico_perf::aot_glue::register_with_vm();
             println!("########## [AOT] bench: AOT factory registered (--aot) ##########");
         }
         #[cfg(not(feature = "aot"))]

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod common;
+
+#[cfg(feature = "aot")]
+pub mod aot_glue;

--- a/sdk/sdk/Cargo.toml
+++ b/sdk/sdk/Cargo.toml
@@ -39,6 +39,6 @@ bb = []     # BabyBear
 kb = []     # KoalaBear
 m31 = []    # Mersenne31
 # Enable the AOT snapshot-main emulator in pico-vm. Consumers must also
-# register an AOT factory (e.g. via examples/aot_common::register_with_vm)
+# register an AOT factory (see `prover/src/aot_glue.rs` in a generated project)
 # before constructing a prover client for the mode flip to take effect.
 aot = ["pico-vm/aot-emulator"]

--- a/vm/src/emulator/aot.rs
+++ b/vm/src/emulator/aot.rs
@@ -1,12 +1,9 @@
 //! AOT snapshot emulator factory.
 //!
-//! This is the cpu-u64 variant — its `AotFactory` signature intentionally
-//! diverges from the gpu-u64 sibling: it does NOT take an
-//! `Arc<RecordFinalPvsState>`. Cpu-u64 has no `Condvar`-based cross-thread
-//! waiter for the final committed digest; the sequencer derives the public
-//! values from replayed worker records via
-//! `EmulationDeferredState::update_public_values`. A future "unify with
-//! gpu-u64" pass should reconcile this divergence.
+//! `AotFactory` deliberately does not carry the final committed digest: there
+//! is no cross-thread waiter for it here. The sequencer instead derives the
+//! public values from replayed worker records via
+//! `EmulationDeferredState::update_public_values`.
 
 use crate::{
     compiler::riscv::program::Program,

--- a/vm/src/proverchain/riscv.rs
+++ b/vm/src/proverchain/riscv.rs
@@ -700,10 +700,9 @@ where
                 // Return this batch's pooled snapshot memory to the recycler so the
                 // bounded GLOBAL_MEMORY_POOL doesn't drain and block the snapshot-main
                 // producer (`build_snapshot_state` recv()s one block per batch). Same
-                // recycle semantics as gpu-base's worker teardown
-                // (GLOBAL_MEMORY_RECYCLER.send((memory, true))) and the standalone AOT
-                // bins' recycle_snapshot_memory(). This CPU pipeline rebuilds `emu` per
-                // batch, so we recycle per batch instead of once at teardown.
+                // recycle semantics as the standalone AOT bins'
+                // recycle_snapshot_memory(). This pipeline rebuilds `emu` per batch, so
+                // we recycle per batch instead of once at teardown.
                 if let Some(emulator) = emu.emulator.take() {
                     let _ = crate::emulator::riscv::memory::GLOBAL_MEMORY_RECYCLER
                         .send((emulator.state.memory, true));


### PR DESCRIPTION
### Summary

Fixes `cargo install --git ... pico-cli` failure caused by a cross-workspace path dependency introduced in #106.

### Problem
`pico-perf` (root workspace) path-depended on `examples/aot_common` (nested `examples` workspace). When installing via Git, Cargo scans the repository, loads both workspaces, and throws a workspace membership error.

### Fix
* **Removed invalid dependency:** Replaced `pico-perf`'s dependency on `examples/aot_common` with a local `src/aot_glue.rs` that directly uses `pico-aot-dispatch` (aligning with the pattern in `prover/src/aot_glue.rs`).